### PR TITLE
Remove mongoose options in tests

### DIFF
--- a/tests/cartRoute.test.js
+++ b/tests/cartRoute.test.js
@@ -18,10 +18,7 @@ describe('Cart Routes - DELETE /api/cart/:productId', () => {
 
   beforeAll(async () => {
     // 1. Connectar a la BD
-    await mongoose.connect(MONGODB_URI, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    });
+    await mongoose.connect(MONGODB_URI);
 
     // 2. Crear un producte de prova
     const product = await Product.create({

--- a/tests/cartService.test.js
+++ b/tests/cartService.test.js
@@ -20,10 +20,7 @@ describe('Cart Service - removeFromCartService', () => {
 
   beforeAll(async () => {
     // 1. Connectar a MongoDB
-    await mongoose.connect(MONGODB_URI, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    });
+    await mongoose.connect(MONGODB_URI);
 
     // 2. Crear dos productes de prova
     const prod1 = await Product.create({


### PR DESCRIPTION
## Summary
- simplify mongoose.connect calls in cart tests

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68419bc909708329b95f51503db4875c