### PR TITLE
Fix Joi address validation message

### DIFF
--- a/src/validators/userValidator.js
+++ b/src/validators/userValidator.js
@@ -35,7 +35,7 @@ export const registerSchema = Joi.object({
       'any.required': 'Surname is required',
     }),
   address: Joi.string().required().messages({
-    'any:required': 'Address  is required',
+    'any.required': 'Address is required',
   }),
 });
 


### PR DESCRIPTION
## Summary
- correct a typo in the `address` field validation message

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68420d6710d08329ba3181d83a1028f0